### PR TITLE
Ignore stderr when execute `openssl` command

### DIFF
--- a/erc-crypt.el
+++ b/erc-crypt.el
@@ -233,7 +233,7 @@ Return NIL on error."
               (insert (base64-encode-string string))
               (list (call-process-region
                      (point-min) (point-max)
-                     erc-crypt-openssl-path t t nil
+                     erc-crypt-openssl-path t '(t nil) nil
                      "enc" "-a" (concat "-" erc-crypt-cipher)
                      "-iv" iv "-K" key "-nosalt")
                     (buffer-string)))
@@ -266,7 +266,7 @@ Return NIL on all errors."
               (insert ciphertext)
               (list (call-process-region
                      (point-min) (point-max)
-                     erc-crypt-openssl-path t t nil
+                     erc-crypt-openssl-path t '(t nil) nil
                      "enc" "-d" "-a" (concat "-" erc-crypt-cipher)
                      "-iv" iv "-K" key "-nosalt")
                     (buffer-string)))


### PR DESCRIPTION
Hi, atomontage

First, thank you for creating this amazing package.

Yesterday I installed this package in my machine (Debian 10), and it did not work. Today after debugging, I see a problem.

The output of `erc-crypt-encrypt` included the stderr of command.

```
(setq string "test string")
(with-temp-buffer
  (insert (base64-encode-string string))
  (list (call-process-region
         (point-min) (point-max)
         "openssl" t '(t nil)  nil
         "enc" "-a" "-aes-256-cbc"
         "-iv" "f55e8b0e1310578e8ea3e6ca3f9ccf81" "-K" "111" "-nosalt")
        (buffer-string)))
```
the  result:
```
(0 "hex string is too short, padding with zero bytes to length
lL0gVV5vYg2ML4H1EQlCCvewd6HYYhlak/wvYNco/Go=
")
```

Then I tried to ignore stderr and it works. 
So I would like to create this PR. Could you have a look?

Thank you very much

